### PR TITLE
switches for brl to build which is needed for bpgl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
       message(FATAL_ERROR "Set VXL_DIR to the location of VXL source directory")
     endif()
     set(VXL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/vxl_build)
+    set(VXL_BUILD_CONTRIB ON CACHE BOOL "build vxl contrib")
+    set(VXL_BUILD_BRL ON CACHE BOOL "build vxl contrib/brl")
+    set(VXL_BUILD_CORE_VIDEO ON CACHE BOOL "build vxl core/vidl")  # required for brl
     add_subdirectory(${VXL_DIR} ${VXL_BINARY_DIR} EXCLUDE_FROM_ALL)
 
     # include core vxl in include paths


### PR DESCRIPTION
pyvxl links to bpgl, however it's never built because brl is never built. Therefore, one needs to enable both brl and core_video (on which brl depends).