### PR TITLE
vpgl_rational_order enumeration via iterator

### DIFF
--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -1,0 +1,35 @@
+import unittest
+
+try:
+  import numpy as np
+except:
+  np = None
+
+from vxl import vpgl
+
+
+# class to test expected enumeration values in pybind11 binding
+class VpglEnumeration(object):
+
+  def test_enum_values(self):
+
+    # test known enumeration elements
+    for item in self.enum_values:
+      self.assertIsNotNone(getattr(self.cls, item, None))
+
+    # test invalid enumeration element
+    with self.assertRaises(AttributeError):
+      self.cls.THIS_IS_AN_INVALID_VALUE
+
+
+# test vpgl_rational_order enumeration
+class VpglRationalOrder(VpglEnumeration, unittest.TestCase):
+
+  def __init__(self, *args, **kwargs):
+    self.cls = vpgl.rational_order
+    self.enum_values = ['VXL', 'RPC00B']
+    super().__init__(*args, **kwargs)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -500,10 +500,10 @@ void wrap_vpgl(py::module &m)
   py::class_<vpgl_rational_camera<double>, vpgl_camera<double> /* <- Parent */ > rational_camera(m, "rational_camera");
 
   // enumerations, attached to parent class
-  py::enum_<vpgl_rational_order>(m, "rational_order")
-    .value("VXL", vpgl_rational_order::VXL)
-    .value("RPC00B", vpgl_rational_order::RPC00B)
-    ;
+  py::enum_<vpgl_rational_order> rational_order(m, "rational_order");
+  for (auto item : vpgl_rational_order_func::initializer_list) {
+    rational_order.value(vpgl_rational_order_func::to_string(item).c_str(), item);
+  }
 
   // enumerations, attached to this class
   py::enum_<vpgl_rational_camera<double>::coor_index>(rational_camera, "coor_index")


### PR DESCRIPTION
`vpgl_rational_order` enumeration definition via iterator
- use `vpgl_rational_order_func::initializer_list` which returns a `std::array` that permits iteration through `vpgl_rational_order` values
- makes compatible with alternative VXL repos containing additional `vpgl_rational_order` choices
- test to check expected `vpgl_rational_order` enumeration values exist in binding