### PR TITLE
Pickle support via vsl_binary_io

### DIFF
--- a/pyvxl_util.h
+++ b/pyvxl_util.h
@@ -1,8 +1,10 @@
 #ifndef pyvxl_util_h_included
 #define pyvxl_util_h_included
 
+#include <pybind11/pybind11.h>
 #include <string>
 #include <sstream>
+#include <vsl/vsl_binary_io.h>
 
 // Return a string based on output of the object's stream operator
 template<typename T>
@@ -11,6 +13,64 @@ std::string streamToString(T const& t){
   std::ostringstream buffer;
   buffer << t;
   return buffer.str();
+}
+
+/* PICKLE VXL CORE INSTANCE with vsl_binary_io
+ *
+ * Any VXL core class with an "io" counterpart can be pickled via
+ * these helper functions.
+ *
+ * Pickle capabilites are added to an object via py::pickle.
+ * Note the appropriate "io" header must also be made available.
+ *
+ *   -----
+ *   #include "../pyvxl_util.h"
+ *   #include <vpgl/io/vpgl_io_affine_camera.h>
+ *
+ *   py::class_< vpgl_affine_camera<double> > (m, "affine_camera")
+ *     .def(py::init ...)
+ *     ...
+ *     .def(py::pickle(&vslPickleGetState< vpgl_affine_camera<double> >,
+ *                     &vslPickleSetState< vpgl_affine_camera<double> >))
+ *     ;
+ *   -----
+ *
+ * Additionally, "target_link_libraries" in CMakeLists.txt must link
+ * to the appropriate "io" target
+ *
+ *   -----
+ *   target_link_libraries(pyvpgl PRIVATE vpgl vpgl_io ...)
+ *                                             ^^^^^^^
+ *   -----
+ *
+ * Assuming the availability of "operator==" for the pickled class,
+ * a python pickle unit test follows this pattern:
+ *
+ *   -----
+ *   def test_pickle(self):
+ *     objA = self.init_obj()
+ *     objB = pickle.loads(pickle.dumps(objA))
+ *     self.assertEqual(objA, objB)
+ *   -----
+ */
+
+template<typename T>
+pybind11::bytes vslPickleGetState(T const& obj)
+{
+  std::ostringstream oss;
+  vsl_b_ostream oss_vsl(&oss);
+  vsl_b_write(oss_vsl, obj);
+  return pybind11::bytes(oss.str());
+}
+
+template<typename T>
+T vslPickleSetState(pybind11::bytes b)
+{
+  T obj;
+  std::istringstream iss(b);
+  vsl_b_istream iss_vsl(&iss);
+  vsl_b_read(iss_vsl, obj);
+  return obj;
 }
 
 #endif

--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -1,12 +1,111 @@
 import unittest
+import pickle
 
-try:
-  import numpy as np
-except:
-  np = None
-
+from vxl import vnl
 from vxl import vpgl
 
+# helper function: populate vnl.matrix_fixed_3x4
+# (without numpy requirement - input is list of lists)
+def matrix_fixed_3x4(data):
+
+  # check size
+  if len(data) != 3 or any(len(row) != 4 for row in data):
+    raise Exception('3x4 matrix expects 3x4 data')
+
+  matrix = vnl.matrix_fixed_3x4()
+  for r in range(matrix.shape[0]):
+    for c in range(matrix.shape[1]):
+      matrix[r,c] = data[r][c]
+
+  return matrix
+
+
+# ----------
+# VPGL CAMERA
+# ----------
+
+# generic camera test class
+class VpglCameraBase(object):
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+  def test_create(self):
+    data = self.test_data['default']
+    cam = self._create_cam(data)
+    self._check_cam(cam, data)
+
+  def test_equal(self):
+    data = self.test_data['default']
+    camA = self._create_cam(data, check = True)
+    camB = self._create_cam(data, check = True)
+    self.assertEqual(camA, camB)
+
+  def test_pickle(self):
+    data = self.test_data['default']
+    camA = self._create_cam(data, check = True)
+    camB = pickle.loads(pickle.dumps(camA))
+    self.assertEqual(camA, camB)
+
+# projective camera
+class VpglProjCamera(VpglCameraBase, unittest.TestCase):
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.cls = vpgl.proj_camera
+
+    # test data
+    self.test_data = {
+      "default": {
+        "matrix": matrix_fixed_3x4([
+            [437.5, 128.5575, -153.20889, 20153.20898],
+            [0.0,  -206.5869, -434.42847, 20434.42968],
+            [0.0,   0.642787,   -0.76604,    100.7660]
+          ]),
+        }
+      }
+
+  def _create_cam(self, data, check = False):
+    cam = self.cls(data['matrix'])
+    if check: self._check_cam(cam, data)
+    return cam
+
+  def _check_cam(self, cam, data):
+    self.assertEqual(cam.get_matrix(), data['matrix'])
+
+# affine camera
+class VpglAffineCamera(VpglCameraBase, unittest.TestCase):
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.cls = vpgl.affine_camera
+
+    # test data
+    self.test_data = {
+      "default": {
+        "matrix": matrix_fixed_3x4([
+            [1.34832357134959380,  0.0038174980872772743,  0.27647870881886161,   8.8599950663932052],
+            [0.21806927892797245, -0.9263109114580021500, -1.00105353309762050, 538.9337651820003400],
+            [0.0, 0.0, 0.0, 1.0]
+          ]),
+        "viewing_distance": 9325.6025071654913,
+        },
+      }
+
+  def _create_cam(self, data, check = False):
+    cam = self.cls(data['matrix'])
+    cam.viewing_distance = data['viewing_distance']
+    if check: self._check_cam(cam, data)
+    return cam
+
+  def _check_cam(self, cam, data):
+    self.assertEqual(cam.get_matrix(), data['matrix'])
+    self.assertEqual(cam.viewing_distance, data['viewing_distance'])
+
+
+# ----------
+# OTHER TESTS
+# ----------
 
 # class to test expected enumeration values in pybind11 binding
 class VpglEnumeration(object):

--- a/vnl/CMakeLists.txt
+++ b/vnl/CMakeLists.txt
@@ -5,7 +5,7 @@ project("pyvxl-vnl")
 pybind11_add_module(pyvnl pyvnl.h pyvnl.cxx)
 
 # Link to vxl library
-target_link_libraries(pyvnl PRIVATE vnl)
+target_link_libraries(pyvnl PRIVATE vnl vnl_io)
 
 # Set names
 set_target_properties(pyvnl PROPERTIES OUTPUT_NAME "_vnl")

--- a/vpgl/CMakeLists.txt
+++ b/vpgl/CMakeLists.txt
@@ -5,7 +5,7 @@ project("pyvxl-vpgl")
 pybind11_add_module(pyvpgl pyvpgl.h pyvpgl.cxx)
 
 # Link to vxl library
-target_link_libraries(pyvpgl PRIVATE vpgl vpgl_file_formats)
+target_link_libraries(pyvpgl PRIVATE vpgl vpgl_io vpgl_file_formats)
 
 # Set names
 set_target_properties(pyvpgl PROPERTIES OUTPUT_NAME "_vpgl")

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -24,9 +24,14 @@
 #include <vil/vil_image_resource.h>
 #include <vil/vil_image_resource_sptr.h>
 
+// io classes for py::pickle
+#include <vpgl/io/vpgl_io_proj_camera.h>
+#include <vpgl/io/vpgl_io_affine_camera.h>
+
 #include "../pyvxl_util.h"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
@@ -443,6 +448,8 @@ void wrap_vpgl(py::module &m)
     .def("is_a", &vpgl_camera<double>::is_a)
     .def("is_class", &vpgl_camera<double>::is_class);
 
+
+  // =====PROJECTIVE CAMERA=====
   py::class_<vpgl_proj_camera<double>, vpgl_camera<double> /* <- Parent */> (m, "proj_camera")
     .def(py::init<vnl_matrix_fixed<double,3,4> >())
     .def("__str__", streamToString<vpgl_proj_camera<double> >)
@@ -450,8 +457,13 @@ void wrap_vpgl(py::module &m)
     .def("project", vpgl_project_point<vpgl_proj_camera<double> >)
     .def("project", vpgl_project_vector<vpgl_proj_camera<double> >)
     .def("project", vpgl_project_xyz<vpgl_proj_camera<double> >)
-    .def("get_matrix", &vpgl_proj_camera<double>::get_matrix, py::return_value_policy::copy);
+    .def("get_matrix", &vpgl_proj_camera<double>::get_matrix, py::return_value_policy::copy)
+    .def(py::self == py::self)
+    .def(py::pickle(&vslPickleGetState<vpgl_proj_camera<double> >,
+                    &vslPickleSetState<vpgl_proj_camera<double> >))
+    ;
 
+  // =====AFFINE CAMERA=====
   py::class_<vpgl_affine_camera<double>, vpgl_proj_camera<double> /* <- Parent */> (m, "affine_camera")
     .def(py::init<vnl_matrix_fixed<double,3,4> >())
     .def(py::init<vgl_vector_3d<double>, vgl_vector_3d<double>, vgl_point_3d<double>,
@@ -468,8 +480,11 @@ void wrap_vpgl(py::module &m)
     .def("ray_dir", &vpgl_affine_camera<double>::ray_dir)
     .def_property("viewing_distance",
                   &vpgl_affine_camera<double>::viewing_distance,  // getter
-                  &vpgl_affine_camera<double>::set_viewing_distance);  // setter
+                  &vpgl_affine_camera<double>::set_viewing_distance)  // setter
     /* .def("set_viewing_distance", &vpgl_affine_camera<double>::set_viewing_distance); */
+    .def(py::pickle(&vslPickleGetState<vpgl_affine_camera<double> >,
+                    &vslPickleSetState<vpgl_affine_camera<double> >))
+    ;
 
   py::class_<vpgl_calibration_matrix<double> >(m, "calibration_matrix")
     .def(py::init<vnl_matrix_fixed<double,3,3> >())


### PR DESCRIPTION
Any VXL core class with an "io" counterpart can be pickled via `vsl_binary_io` to save and restore the object from a byte stream.  This PR implements generic vsl pickling, adds pickle support to vnl & vpgl classes, and adds additional vpgl tests. 