### PR TITLE
pyvxl_add_module function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,67 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl")
 
+# pyvxl project source directory
+set(PYVXL_PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
+
+# print pyvxl debug messages during cmake
+set(PYVXL_DEBUG_MESSAGES "OFF" CACHE BOOL "Print pyvxl debug messages")
+
+# function: add pyvxl module
+function(pyvxl_add_module vxl_name)
+
+    # target variables
+    set(target_name "py${vxl_name}")
+    set(output_name "_${vxl_name}")
+
+    # target files
+    set(target_file_h "${CMAKE_CURRENT_SOURCE_DIR}/${target_name}.h")
+    set(target_file_cxx "${CMAKE_CURRENT_SOURCE_DIR}/${target_name}.cxx")
+    set(target_files ${target_file_h} ${target_file_cxx})
+
+    # install directory
+    string(REPLACE
+           "${PYVXL_PROJECT_SOURCE_DIR}" # string to be replaced
+           "${PYTHON_SITE}/vxl"          # replace with this
+           install_dir                   # output
+           "${CMAKE_CURRENT_SOURCE_DIR}" # input
+           )
+
+    # debug messages (currently disabled)
+    if (PYVXL_DEBUG_MESSAGES)
+        message(STATUS "PYVXL_ADD_MODULE:")
+        message(STATUS "  vxl_name     = ${vxl_name}")
+        message(STATUS "  target_name  = ${target_name}")
+        message(STATUS "  output_name  = ${output_name}")
+        message(STATUS "  target_files = ${target_files}")
+        message(STATUS "  install_dir  = ${install_dir}")
+    endif()
+
+    # install directory setup
+    install(DIRECTORY DESTINATION ${install_dir})
+    install(FILES __init__.py DESTINATION ${install_dir})
+
+    # initialize target if necessary
+    if (EXISTS "${target_file_h}")
+        message(STATUS "pyvxl found ${target_name}")
+
+        # Add pybind11 module
+        pybind11_add_module(${target_name} ${target_files})
+
+        # Link to vxl library
+        target_link_libraries(${target_name} PRIVATE ${vxl_name})
+
+        # Set output_name of target
+        set_target_properties(${target_name} PROPERTIES OUTPUT_NAME ${output_name})
+
+        # target installation
+        install(TARGETS ${target_name} DESTINATION ${install_dir})
+
+    endif()
+
+endfunction()
+
+
 # If building PyVXL directly, build VXL and pybind11
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     set(PYVXL_TOP_LEVEL TRUE)

--- a/contrib/bpgl/CMakeLists.txt
+++ b/contrib/bpgl/CMakeLists.txt
@@ -1,12 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bpgl")
 
-# Create the algo install directory in case it doesn't exist yet
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl)
+# add as pyvxl module
+pyvxl_add_module(bpgl)
 
 # Recurse
 add_subdirectory("algo" "algo-build")
-

--- a/contrib/bpgl/CMakeLists.txt
+++ b/contrib/bpgl/CMakeLists.txt
@@ -4,8 +4,8 @@ project("pyvxl-contrib-bpgl")
 # Create the algo install directory in case it doesn't exist yet
 install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
 
-# auto generate __init__ file to load algo submodule by default
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/contrib/bpgl/__init__.py \"from . import algo\")")
+# copy __init__ file over into module
+install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl)
 
 # Recurse
 add_subdirectory("algo" "algo-build")

--- a/contrib/bpgl/__init__.py
+++ b/contrib/bpgl/__init__.py
@@ -1,0 +1,2 @@
+# from ._bpgl import *
+from . import algo

--- a/contrib/bpgl/algo/CMakeLists.txt
+++ b/contrib/bpgl/algo/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bpgl-algo")
 
-# Add pybind11 module
-pybind11_add_module(pybpgl_algo pybpgl_algo.h pybpgl_algo.cxx)
-
-# Link to vxl library
-target_link_libraries(pybpgl_algo PRIVATE bpgl_algo)
-
-# Set names
-set_target_properties(pybpgl_algo PROPERTIES OUTPUT_NAME "_bpgl_algo")
-
-# install the .so file to the python install dir
-install(TARGETS pybpgl_algo DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
-
+# add as pyvxl module
+pyvxl_add_module(bpgl_algo)

--- a/contrib/bpgl/algo/CMakeLists.txt
+++ b/contrib/bpgl/algo/CMakeLists.txt
@@ -13,6 +13,6 @@ set_target_properties(pybpgl_algo PROPERTIES OUTPUT_NAME "_bpgl_algo")
 # install the .so file to the python install dir
 install(TARGETS pybpgl_algo DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
 
-# auto generate __init__ file
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/contrib/bpgl/algo/__init__.py \"from ._bpgl_algo import *\")")
+# copy __init__ file over into module
+install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl/algo)
 

--- a/contrib/bpgl/algo/__init__.py
+++ b/contrib/bpgl/algo/__init__.py
@@ -1,0 +1,1 @@
+from ._bpgl_algo import *

--- a/contrib/brad/CMakeLists.txt
+++ b/contrib/brad/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-brad")
 
-# Add pybind11 module
-pybind11_add_module(pybrad pybrad.h pybrad.cxx)
-
-# Link to vxl library
-target_link_libraries(pybrad PRIVATE brad)
-
-# Set names
-set_target_properties(pybrad PROPERTIES OUTPUT_NAME "_brad")
-
-# install the .so file to the python install dir
-install(TARGETS pybrad DESTINATION ${PYTHON_SITE}/vxl/contrib/brad)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/brad)
-
+# add as pyvxl module
+pyvxl_add_module(brad)

--- a/contrib/brip/CMakeLists.txt
+++ b/contrib/brip/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-brip")
 
-# Add pybind11 module
-pybind11_add_module(pybrip pybrip.h pybrip.cxx)
-
-# Link to vxl library
-target_link_libraries(pybrip PRIVATE brip)
-
-# Set names
-set_target_properties(pybrip PROPERTIES OUTPUT_NAME "_brip")
-
-# install the .so file to the python install dir
-install(TARGETS pybrip DESTINATION ${PYTHON_SITE}/vxl/contrib/brip)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/brip)
-
+# add as pyvxl module
+pyvxl_add_module(brip)

--- a/contrib/bvxm/CMakeLists.txt
+++ b/contrib/bvxm/CMakeLists.txt
@@ -1,21 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bvxm")
 
-# Add pybind11 module
-pybind11_add_module(pybvxm pybvxm.h pybvxm.cxx)
-
-# Link to vxl library
-target_link_libraries(pybvxm PRIVATE bvxm)
-
-# Set names
-set_target_properties(pybvxm PROPERTIES OUTPUT_NAME "_bvxm")
-
-# install the .so file to the python install dir
-install(TARGETS pybvxm DESTINATION ${PYTHON_SITE}/vxl/contrib/bvxm)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bvxm)
+# add as pyvxl module
+pyvxl_add_module(bvxm)
 
 # Recurse
 add_subdirectory("algo" "algo-build")
-

--- a/contrib/bvxm/algo/CMakeLists.txt
+++ b/contrib/bvxm/algo/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bvxm-algo")
 
-# Add pybind11 module
-pybind11_add_module(pybvxm_algo pybvxm_algo.h pybvxm_algo.cxx)
-
-# Link to vxl library
-target_link_libraries(pybvxm_algo PRIVATE bvxm_algo)
-
-# Set names
-set_target_properties(pybvxm_algo PROPERTIES OUTPUT_NAME "_bvxm_algo")
-
-# install the .so file to the python install dir
-install(TARGETS pybvxm_algo DESTINATION ${PYTHON_SITE}/vxl/contrib/bvxm/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/bvxm/algo)
-
+# add as pyvxl module
+pyvxl_add_module(bvxm_algo)

--- a/contrib/sdet/CMakeLists.txt
+++ b/contrib/sdet/CMakeLists.txt
@@ -1,21 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-sdet")
 
-# Add pybind11 module
-pybind11_add_module(pysdet pysdet.h pysdet.cxx)
-
-# Link to vxl library
-target_link_libraries(pysdet PRIVATE sdet)
-
-# Set names
-set_target_properties(pysdet PROPERTIES OUTPUT_NAME "_sdet")
-
-# install the .so file to the python install dir
-install(TARGETS pysdet DESTINATION ${PYTHON_SITE}/vxl/contrib/sdet)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/sdet)
+# add as pyvxl module
+pyvxl_add_module(sdet)
 
 # Recurse
 add_subdirectory("algo" "algo-build")
-

--- a/contrib/sdet/algo/CMakeLists.txt
+++ b/contrib/sdet/algo/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-sdet-algo")
 
-# Add pybind11 module
-pybind11_add_module(pysdet_algo pysdet_algo.h pysdet_algo.cxx)
-
-# Link to vxl library
-target_link_libraries(pysdet_algo PRIVATE sdet_algo)
-
-# Set names
-set_target_properties(pysdet_algo PROPERTIES OUTPUT_NAME "_sdet_algo")
-
-# install the .so file to the python install dir
-install(TARGETS pysdet_algo DESTINATION ${PYTHON_SITE}/vxl/contrib/sdet/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/contrib/sdet/algo)
-
+# add as pyvxl module
+pyvxl_add_module(sdet_algo)

--- a/vgl/CMakeLists.txt
+++ b/vgl/CMakeLists.txt
@@ -1,24 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vgl")
 
-# Add pybind11 module
-pybind11_add_module(pyvgl pyvgl.h pyvgl.cxx)
-
-# Link to vxl library
-target_link_libraries(pyvgl PRIVATE vgl)
-
-# Set names
-set_target_properties(pyvgl PROPERTIES OUTPUT_NAME "_vgl")
-
-# install the .so file to the python install dir
-install(TARGETS pyvgl DESTINATION ${PYTHON_SITE}/vxl/vgl)
-
-# Create the algo install directory in case it doesn't exist
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vgl/)
+# add as pyvxl module
+pyvxl_add_module(vgl)
 
 # Recurse
 add_subdirectory("algo" "algo-build")
-

--- a/vgl/algo/CMakeLists.txt
+++ b/vgl/algo/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vgl-algo")
 
-# Add pybind11 module
-pybind11_add_module(pyvgl_algo pyvgl_algo.h pyvgl_algo.cxx)
-
-# Link to vxl library
-target_link_libraries(pyvgl_algo PRIVATE vgl_algo)
-
-# Set names
-set_target_properties(pyvgl_algo PROPERTIES OUTPUT_NAME "_vgl_algo")
-
-# install the .so file to the python install dir
-install(TARGETS pyvgl_algo DESTINATION ${PYTHON_SITE}/vxl/vgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vgl/algo)
-
+# add as pyvxl module
+pyvxl_add_module(vgl_algo)

--- a/vgl/algo/CMakeLists.txt
+++ b/vgl/algo/CMakeLists.txt
@@ -13,6 +13,6 @@ set_target_properties(pyvgl_algo PROPERTIES OUTPUT_NAME "_vgl_algo")
 # install the .so file to the python install dir
 install(TARGETS pyvgl_algo DESTINATION ${PYTHON_SITE}/vxl/vgl/algo)
 
-# auto generate __init__ file
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/vgl/algo/__init__.py \"from ._vgl_algo import *\")")
+# copy __init__ file over into module
+install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vgl/algo)
 

--- a/vgl/algo/__init__.py
+++ b/vgl/algo/__init__.py
@@ -1,0 +1,1 @@
+from ._vgl_algo import *

--- a/vil/CMakeLists.txt
+++ b/vil/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vil")
 
-# Add pybind11 module
-pybind11_add_module(pyvil pyvil.h pyvil.cxx)
-
-# Link to vxl library
-target_link_libraries(pyvil PRIVATE vil)
-
-# Set names
-set_target_properties(pyvil PROPERTIES OUTPUT_NAME "_vil")
-
-# install the .so file to the python install dir
-install(TARGETS pyvil DESTINATION ${PYTHON_SITE}/vxl/vil)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vil)
-
+# add as pyvxl module
+pyvxl_add_module(vil)

--- a/vnl/CMakeLists.txt
+++ b/vnl/CMakeLists.txt
@@ -13,6 +13,6 @@ set_target_properties(pyvnl PROPERTIES OUTPUT_NAME "_vnl")
 # install the .so file to the python install dir
 install(TARGETS pyvnl DESTINATION ${PYTHON_SITE}/vxl/vnl)
 
-# auto generate __init__ file
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/vnl/__init__.py \"from ._vnl import *\")")
+# copy __init__ file over into module
+install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vnl)
 

--- a/vnl/CMakeLists.txt
+++ b/vnl/CMakeLists.txt
@@ -1,18 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vnl")
 
-# Add pybind11 module
-pybind11_add_module(pyvnl pyvnl.h pyvnl.cxx)
+# add as pyvxl module
+pyvxl_add_module(vnl)
 
-# Link to vxl library
-target_link_libraries(pyvnl PRIVATE vnl vnl_io)
-
-# Set names
-set_target_properties(pyvnl PROPERTIES OUTPUT_NAME "_vnl")
-
-# install the .so file to the python install dir
-install(TARGETS pyvnl DESTINATION ${PYTHON_SITE}/vxl/vnl)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vnl)
-
+# additional linking
+target_link_libraries(pyvnl PRIVATE vnl_io)

--- a/vnl/__init__.py
+++ b/vnl/__init__.py
@@ -1,0 +1,1 @@
+from ._vnl import *

--- a/vpgl/CMakeLists.txt
+++ b/vpgl/CMakeLists.txt
@@ -1,24 +1,11 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vpgl")
 
-# Add pybind11 module
-pybind11_add_module(pyvpgl pyvpgl.h pyvpgl.cxx)
+# add as pyvxl module
+pyvxl_add_module(vpgl)
 
-# Link to vxl library
-target_link_libraries(pyvpgl PRIVATE vpgl vpgl_io vpgl_file_formats)
-
-# Set names
-set_target_properties(pyvpgl PROPERTIES OUTPUT_NAME "_vpgl")
-
-# install the .so file to the python install dir
-install(TARGETS pyvpgl DESTINATION ${PYTHON_SITE}/vxl/vpgl)
-
-# Create the algo install directory in case it doesn't exist
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vpgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vpgl)
+# additional linking
+target_link_libraries(pyvpgl PRIVATE vpgl_io vpgl_file_formats)
 
 # Recurse
 add_subdirectory("algo" "algo-build")
-

--- a/vpgl/algo/CMakeLists.txt
+++ b/vpgl/algo/CMakeLists.txt
@@ -13,6 +13,6 @@ set_target_properties(pyvpgl_algo PROPERTIES OUTPUT_NAME "_vpgl_algo")
 # install the .so file to the python install dir
 install(TARGETS pyvpgl_algo DESTINATION ${PYTHON_SITE}/vxl/vpgl/algo)
 
-# auto generate __init__ file
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/vpgl/algo/__init__.py \"from ._vpgl_algo import *\")")
+# copy __init__ file over into module
+install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vpgl/algo)
 

--- a/vpgl/algo/CMakeLists.txt
+++ b/vpgl/algo/CMakeLists.txt
@@ -1,18 +1,5 @@
 cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vpgl-algo")
 
-# Add pybind11 module
-pybind11_add_module(pyvpgl_algo pyvpgl_algo.h pyvpgl_algo.cxx)
-
-# Link to vxl library
-target_link_libraries(pyvpgl_algo PRIVATE vpgl_algo)
-
-# Set names
-set_target_properties(pyvpgl_algo PROPERTIES OUTPUT_NAME "_vpgl_algo")
-
-# install the .so file to the python install dir
-install(TARGETS pyvpgl_algo DESTINATION ${PYTHON_SITE}/vxl/vpgl/algo)
-
-# copy __init__ file over into module
-install(FILES __init__.py DESTINATION ${PYTHON_SITE}/vxl/vpgl/algo)
-
+# add as pyvxl module
+pyvxl_add_module(vpgl_algo)

--- a/vpgl/algo/__init__.py
+++ b/vpgl/algo/__init__.py
@@ -1,0 +1,1 @@
+from ._vpgl_algo import *


### PR DESCRIPTION
Define a general cmake function `pyvxl_add_module` to add a submodule to pyvxl.  This function will initialize the install directory, copy the `__init__.py` file, and setup the target if an expected header file exists.  

Other changes to support this new function.