### PR TITLE
auto-init submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,21 +119,8 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(PYTHON_SITE ${PYTHON_SITE_DEFAULT} CACHE STRING "Python installation directory")
 
-# Create the install directories in case they aren't installed to, so auto-loading doesn't break
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vgl)
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vil)
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vnl)
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/vpgl)
-install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib)
-
-# generate __init__ file to auto-load modules by default
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/__init__.py \"\
-from . import vgl\n\
-from . import vil\n\
-from . import vnl\n\
-from . import vpgl\n\
-from . import contrib\n\
-\")")
+# add main module
+pyvxl_add_module(vxl)
 
 # Recurse
 add_subdirectory("vgl" "pyvxl_build/vgl-build")

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,31 @@
+# import pyvxl, recursively importing all available submodules
+def __import():
+
+  import importlib
+  import pkgutil
+
+  # helper function: recursively import submodules
+  def import_submodules(package):
+    results = {}
+    for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):
+      if not is_pkg: continue
+
+      full_name = package.__name__ + '.' + name
+      _module = importlib.import_module(full_name)
+      results[full_name] = _module
+      results.update(import_submodules(_module))
+
+    return results
+
+  # import all submodules
+  main_module = importlib.import_module(__name__)
+  modules = import_submodules(main_module)
+  return modules
+
+
+# save complete list of submodules
+__sub_mod__ = list(__import().keys())
+
+# list of top-level submodules
+__all__ = [key.split('.')[-1] for key in __sub_mod__
+           if key.count('.') == 1]

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -11,61 +11,27 @@ set(PYVXL_CONTRIB_MAKE_BRIP ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on BRIP b
 set(PYVXL_CONTRIB_MAKE_BVXM ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on BVXM build")
 set(PYVXL_CONTRIB_MAKE_SDET ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on SDET build")
 
-# Overwrite existing __init__ file
-install(CODE "file(WRITE ${PYTHON_SITE}/vxl/contrib/__init__.py \"\")")
+# add "contrib" module
+pyvxl_add_module(contrib)
 
+# Recurse
 if (PYVXL_CONTRIB_MAKE_BPGL)
-  # Create the bpgl install directory since it doesn't exist yet
-  install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/bpgl)
-
-  # auto generate __init__ file
-  install(CODE "file(APPEND ${PYTHON_SITE}/vxl/contrib/__init__.py \"\nfrom . import bpgl\")")
-
-  # Recurse
   add_subdirectory("bpgl" "bpgl-build")
 endif()
 
 if (PYVXL_CONTRIB_MAKE_BRAD)
-  # Create the brad install directory since it doesn't exist yet
-  install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/brad)
-
-  # auto generate __init__ file
-  install(CODE "file(APPEND ${PYTHON_SITE}/vxl/contrib/__init__.py \"\nfrom . import brad\")")
-
-  # Recurse
   add_subdirectory("brad" "brad-build")
 endif()
 
 if (PYVXL_CONTRIB_MAKE_BRIP)
-  # Create the brip install directory since it doesn't exist yet
-  install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/brip)
-
-  # auto generate __init__ file
-  install(CODE "file(APPEND ${PYTHON_SITE}/vxl/contrib/__init__.py \"\nfrom . import brip\")")
-
-  # Recurse
   add_subdirectory("brip" "brip-build")
 endif()
 
 if (PYVXL_CONTRIB_MAKE_BVXM)
-  # Create the bvxm install directory since it doesn't exist yet
-  install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/bvxm)
-
-  # auto generate __init__ file
-  install(CODE "file(APPEND ${PYTHON_SITE}/vxl/contrib/__init__.py \"\nfrom . import bvxm\")")
-
-  # Recurse
   add_subdirectory("bvxm" "bvxm-build")
 endif()
 
 if (PYVXL_CONTRIB_MAKE_SDET)
-  # Create the sdet install directory since it doesn't exist yet
-  install(DIRECTORY DESTINATION ${PYTHON_SITE}/vxl/contrib/sdet)
-
-  # auto generate __init__ file
-  install(CODE "file(APPEND ${PYTHON_SITE}/vxl/contrib/__init__.py \"\nfrom . import sdet\")")
-
-  # Recurse
   add_subdirectory("sdet" "sdet-build")
 endif()
 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -11,27 +11,43 @@ set(PYVXL_CONTRIB_MAKE_BRIP ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on BRIP b
 set(PYVXL_CONTRIB_MAKE_BVXM ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on BVXM build")
 set(PYVXL_CONTRIB_MAKE_SDET ${PYVXL_CONTRIB_MAKE_ALL} CACHE BOOL "Turn on SDET build")
 
-# add "contrib" module
-pyvxl_add_module(contrib)
-
-# Recurse
-if (PYVXL_CONTRIB_MAKE_BPGL)
-  add_subdirectory("bpgl" "bpgl-build")
+# is ANY contrib guard active
+if (   ${PYVXL_CONTRIB_MAKE_ALL}
+    OR ${PYVXL_CONTRIB_MAKE_BPGL}
+    OR ${PYVXL_CONTRIB_MAKE_BRAD}
+    OR ${PYVXL_CONTRIB_MAKE_BRIP}
+    OR ${PYVXL_CONTRIB_MAKE_BVXM}
+    OR ${PYVXL_CONTRIB_MAKE_SDET}
+    )
+  set(pyvxl_contrib_make_any TRUE)
+else()
+  set(pyvxl_contrib_make_any FALSE)
 endif()
 
-if (PYVXL_CONTRIB_MAKE_BRAD)
-  add_subdirectory("brad" "brad-build")
-endif()
+# add "contrib" module if necessary
+if (pyvxl_contrib_make_any)
+  pyvxl_add_module(contrib)
 
-if (PYVXL_CONTRIB_MAKE_BRIP)
-  add_subdirectory("brip" "brip-build")
-endif()
+  # Recurse
+  if (PYVXL_CONTRIB_MAKE_BPGL)
+    add_subdirectory("bpgl" "bpgl-build")
+  endif()
 
-if (PYVXL_CONTRIB_MAKE_BVXM)
-  add_subdirectory("bvxm" "bvxm-build")
-endif()
+  if (PYVXL_CONTRIB_MAKE_BRAD)
+    add_subdirectory("brad" "brad-build")
+  endif()
 
-if (PYVXL_CONTRIB_MAKE_SDET)
-  add_subdirectory("sdet" "sdet-build")
+  if (PYVXL_CONTRIB_MAKE_BRIP)
+    add_subdirectory("brip" "brip-build")
+  endif()
+
+  if (PYVXL_CONTRIB_MAKE_BVXM)
+    add_subdirectory("bvxm" "bvxm-build")
+  endif()
+
+  if (PYVXL_CONTRIB_MAKE_SDET)
+    add_subdirectory("sdet" "sdet-build")
+  endif()
+
 endif()
 

--- a/contrib/bpgl/__init__.py
+++ b/contrib/bpgl/__init__.py
@@ -1,2 +1,2 @@
 # from ._bpgl import *
-from . import algo
+

--- a/contrib/bvxm/__init__.py
+++ b/contrib/bvxm/__init__.py
@@ -1,2 +1,2 @@
 from ._bvxm import *
-from . import algo
+

--- a/contrib/sdet/__init__.py
+++ b/contrib/sdet/__init__.py
@@ -1,3 +1,2 @@
 from ._sdet import *
-from . import algo
 

--- a/vgl/__init__.py
+++ b/vgl/__init__.py
@@ -1,3 +1,2 @@
 from ._vgl import *
-from . import algo
 

--- a/vpgl/__init__.py
+++ b/vpgl/__init__.py
@@ -1,5 +1,4 @@
 from ._vpgl import *
-from . import algo
 
 
 def load_rational_camera(cam_fname):


### PR DESCRIPTION
`import vxl` will now automatically recursively import all available submodules.  Submodules need not directly import children, e.g., `vpgl/__init__.py` does not need to include ` from . import algo`.