### PR TITLE
cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.10.2) # same as vxl
 project("pyvxl")
 
 # pyvxl project source directory

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -12,7 +12,6 @@
 # contrib modules, initialze a PYVXL_CONTRIB_MAKE_* guard if one does not
 # exist, and add the contrib subdirectory if necessary.
 #
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib")
 
 # build all guard

--- a/contrib/bpgl/CMakeLists.txt
+++ b/contrib/bpgl/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bpgl")
 
 # add as pyvxl module

--- a/contrib/bpgl/algo/CMakeLists.txt
+++ b/contrib/bpgl/algo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bpgl-algo")
 
 # add as pyvxl module

--- a/contrib/brad/CMakeLists.txt
+++ b/contrib/brad/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-brad")
 
 # add as pyvxl module

--- a/contrib/brip/CMakeLists.txt
+++ b/contrib/brip/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-brip")
 
 # add as pyvxl module

--- a/contrib/bvxm/CMakeLists.txt
+++ b/contrib/bvxm/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bvxm")
 
 # add as pyvxl module

--- a/contrib/bvxm/algo/CMakeLists.txt
+++ b/contrib/bvxm/algo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-bvxm-algo")
 
 # add as pyvxl module

--- a/contrib/sdet/CMakeLists.txt
+++ b/contrib/sdet/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-sdet")
 
 # add as pyvxl module

--- a/contrib/sdet/algo/CMakeLists.txt
+++ b/contrib/sdet/algo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-contrib-sdet-algo")
 
 # add as pyvxl module

--- a/vgl/CMakeLists.txt
+++ b/vgl/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vgl")
 
 # add as pyvxl module

--- a/vgl/algo/CMakeLists.txt
+++ b/vgl/algo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vgl-algo")
 
 # add as pyvxl module

--- a/vil/CMakeLists.txt
+++ b/vil/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vil")
 
 # add as pyvxl module

--- a/vnl/CMakeLists.txt
+++ b/vnl/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vnl")
 
 # add as pyvxl module

--- a/vpgl/CMakeLists.txt
+++ b/vpgl/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vpgl")
 
 # add as pyvxl module

--- a/vpgl/algo/CMakeLists.txt
+++ b/vpgl/algo/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
 project("pyvxl-vpgl-algo")
 
 # add as pyvxl module


### PR DESCRIPTION
Update top-level `cmake_minimum_required` to match current VXL requirement.

Eliminate unnecessary subdirectory calls to `cmake_minimum_required` as per https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html