### PR TITLE
cmake - explicit contrib directory list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,18 +61,6 @@ function(pyvxl_add_module vxl_name)
 
 endfunction()
 
-# function: list of subdirectories relative to ${input_dir}
-function(get_subdir_list input_dir result_name)
-    file(GLOB children RELATIVE ${input_dir} ${input_dir}/*)
-    set(dir_list "")
-    foreach(child ${children})
-        if(IS_DIRECTORY ${input_dir}/${child})
-            list(APPEND dir_list ${child})
-        endif()
-    endforeach()
-    set(${result_name} ${dir_list} PARENT_SCOPE)
-endfunction()
-
 
 # If building PyVXL directly, build VXL and pybind11
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
@@ -135,7 +123,7 @@ set(PYTHON_SITE ${PYTHON_SITE_DEFAULT} CACHE STRING "Python installation directo
 pyvxl_add_module(vxl)
 
 # add core components
-set(core_components "vgl" "vil" "vnl" "vpgl")
+set(core_components vgl vil vnl vpgl)
 foreach(component ${core_components})
     add_subdirectory("${component}" "pyvxl_build/${component}-build")
 endforeach()

--- a/README.md
+++ b/README.md
@@ -72,3 +72,59 @@ add_subdirectory(${Your pybind11 dir})
 add_subdirectory(${Your pyvxl dir})
 ```
 
+## Adding a new contrib module
+
+To add a new contrib module `xyz`:
+- Add `xyz` to the list of `contrib_components` in `contrib/CMakeLists.txt`
+- Create a new directory `contrib/xyz`
+- Add required files to new directory per the below
+
+Required files for contrib module `xyz` are as follows:
+
+_CMakeLists.txt_
+```cmake
+project("pyvxl-contrib-xyz")
+pyvxl_add_module(xyz)
+```
+
+_pyxyz.h_
+```c++
+#ifndef pyxyz_h_included_
+#define pyxyz_h_included_
+
+#include <pybind11/pybind11.h>
+
+namespace pyvxl { namespace xyz {
+
+void wrap_xyz(pybind11::module &m);
+
+}}
+
+#endif  // pyxyz_h_included_
+```
+
+_pyxyz.cxx_
+```c++
+#include "pyxyz.h"
+
+namespace py = pybind11;
+
+namespace pyvxl { namespace xyz {
+
+void wrap_xyz(py::module &m)
+{
+  // wrapping code ...
+}
+
+}}
+
+PYBIND11_MODULE(_xyz, m)
+{
+  m.doc() =  "Python bindings for the VXL contrib XYZ computer vision library";
+  pyvxl::xyz::wrap_xyz(m);
+}
+```
+_\_\_init\_\_.py_
+```python
+from ._xyz import *
+```

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -18,7 +18,7 @@ project("pyvxl-contrib")
 set(PYVXL_CONTRIB_MAKE_ALL FALSE CACHE BOOL "Build every optional pyvxl contrib module")
 
 # list of contrib components
-get_subdir_list("${CMAKE_CURRENT_SOURCE_DIR}" contrib_components)
+set(contrib_components bpgl brad brip bvxm sdet)
 
 # has base contrib module already been added?
 set(contrib_added FALSE)


### PR DESCRIPTION
To ensure a `make` re-run catches new contrib directories, explicitly list contrib directories in the `contrib/CMakeLists.txt`. Update readme with procedure for adding new contrib directory.

Addressing https://github.com/VisionSystemsInc/pyvxl/pull/72#issuecomment-567094362