### PR TITLE
Auto import dependencies

### DIFF
--- a/contrib/bpgl/algo/__init__.py
+++ b/contrib/bpgl/algo/__init__.py
@@ -1,1 +1,2 @@
 from ._bpgl_algo import *
+from vxl import vil

--- a/contrib/brad/__init__.py
+++ b/contrib/brad/__init__.py
@@ -1,2 +1,3 @@
 from ._brad import *
-
+from vxl import vgl
+from vxl import vil

--- a/contrib/brad/pybrad.cxx
+++ b/contrib/brad/pybrad.cxx
@@ -1,5 +1,4 @@
 #include "pybrad.h"
-
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>

--- a/contrib/brip/__init__.py
+++ b/contrib/brip/__init__.py
@@ -1,4 +1,5 @@
 from ._brip import *
+from vxl import vil
 
 
 def truncate_nitf_image(img, is_byte, is_scale):

--- a/contrib/bvxm/__init__.py
+++ b/contrib/bvxm/__init__.py
@@ -1,2 +1,3 @@
 from ._bvxm import *
-
+from vxl import vgl
+from vxl import vil

--- a/contrib/sdet/algo/__init__.py
+++ b/contrib/sdet/algo/__init__.py
@@ -1,2 +1,2 @@
 from ._sdet_algo import *
-
+from vxl import vil

--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -4,6 +4,7 @@ import pickle
 from vxl import vnl
 from vxl import vpgl
 
+
 # helper function: populate vnl.matrix_fixed_3x4
 # (without numpy requirement - input is list of lists)
 def matrix_fixed_3x4(data):
@@ -15,7 +16,7 @@ def matrix_fixed_3x4(data):
   matrix = vnl.matrix_fixed_3x4()
   for r in range(matrix.shape[0]):
     for c in range(matrix.shape[1]):
-      matrix[r,c] = data[r][c]
+      matrix[r, c] = data[r][c]
 
   return matrix
 
@@ -55,6 +56,7 @@ class VpglCameraBase(object):
     camB = pickle.loads(pickle.dumps(camA))
     self.assertEqual(camA, camB)
 
+
 # projective camera
 class VpglProjCamera(VpglCameraBase, unittest.TestCase):
 
@@ -69,9 +71,9 @@ class VpglProjCamera(VpglCameraBase, unittest.TestCase):
             [437.5, 128.5575, -153.20889, 20153.20898],
             [0.0,  -206.5869, -434.42847, 20434.42968],
             [0.0,   0.642787,   -0.76604,    100.7660]
-          ]),
-        }
+        ]),
       }
+    }
 
   def _create_cam(self, data, check = False):
     cam = self.cls(data['matrix'])
@@ -80,6 +82,7 @@ class VpglProjCamera(VpglCameraBase, unittest.TestCase):
 
   def _check_cam(self, cam, data):
     self.assertEqual(cam.get_matrix(), data['matrix'])
+
 
 # affine camera
 class VpglAffineCamera(VpglCameraBase, unittest.TestCase):
@@ -97,8 +100,8 @@ class VpglAffineCamera(VpglCameraBase, unittest.TestCase):
             [0.0, 0.0, 0.0, 1.0]
           ]),
         "viewing_distance": 9325.6025071654913,
-        },
-      }
+      },
+    }
 
   def _create_cam(self, data, check = False):
     cam = self.cls(data['matrix'])

--- a/vgl/algo/__init__.py
+++ b/vgl/algo/__init__.py
@@ -1,1 +1,2 @@
 from ._vgl_algo import *
+from vxl import vnl

--- a/vpgl/__init__.py
+++ b/vpgl/__init__.py
@@ -1,4 +1,5 @@
 from ._vpgl import *
+from vxl import vnl
 
 
 def load_rational_camera(cam_fname):


### PR DESCRIPTION
PR #71 removed the auto-import of VXL core. Any VXL module containing functions that return VXL core objects (e.g. vil image views) needs to explicitly import the appropriate VXL core module. This PR is an attempt to cover this need, but may not be comprehensive. Objects may have members that have methods, etc. with a long chain of events leading to a new core requirement. These dependencies will need to be patched as the need arises.