### PR TITLE
ninja jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: compile
           working_directory: /build
-          command: ninja
+          command: set -x && ninja -j${NINJA_JOBS:-$((`nproc` / 2))}
 
       - run:
           name: install


### PR DESCRIPTION
Better control of ninja jobs during compile step (intended to stop build thrashing)
- `NINJA_JOBS` environment variable for direct control
- default to `nproc/2` (typically 18 jobs for circleci)