### PR TITLE
vpgl save/load & unit tests

### DIFF
--- a/vgl/algo/pyvgl_algo.cxx
+++ b/vgl/algo/pyvgl_algo.cxx
@@ -44,7 +44,9 @@ void wrap_vgl_algo(py::module &m)
     .def("__repr__", streamToString<vgl_rotation_3d<double> >)
     .def(py::self * vgl_vector_3d<double>())
     .def(py::self * vgl_point_3d<double>())
-    .def(py::self * py::self);
+    .def(py::self * py::self)
+    .def(py::self == py::self)
+    ;
 
 }
 }}}


### PR DESCRIPTION
- Expand vpgl save/load to more camera types (proj_camera, affine_camera, and perspective_camera). 
- Add save/load test using `np.testing.assert_allclose()` to check object similarity given limited ASCII precision.
- Add unit tests for vpgl.perspective_camera, including necessary binding update for tests to pass.