### PR TITLE
bsgm_prob_pairwise_dsm update

### DIFF
--- a/contrib/bsgm/pybsgm.cxx
+++ b/contrib/bsgm/pybsgm.cxx
@@ -114,6 +114,8 @@ void wrap_bsgm_prob_pairwise_dsm(py::module &m, std::string const& class_name)
          "probabilistic heightmap")
     .def("prob_confidence", &BSGM_T::prob_confidence,
          "probabilistic confidence")
+    .def("radial_std_dev_image", &BSGM_T::radial_std_dev_image,
+         "radial standard deviation")
 
     .def("rectify", &BSGM_T::rectify,
          py::call_guard<py::gil_scoped_release>(),

--- a/contrib/bsgm/pybsgm.cxx
+++ b/contrib/bsgm/pybsgm.cxx
@@ -116,22 +116,29 @@ void wrap_bsgm_prob_pairwise_dsm(py::module &m, std::string const& class_name)
          "probabilistic confidence")
 
     .def("rectify", &BSGM_T::rectify,
+         py::call_guard<py::gil_scoped_release>(),
          "image rectification")
 
     .def("compute_disparity_fwd", &BSGM_T::compute_disparity_fwd,
+         py::call_guard<py::gil_scoped_release>(),
          "compute forward disparity")
     .def("compute_disparity_rev", &BSGM_T::compute_disparity_rev,
+         py::call_guard<py::gil_scoped_release>(),
          "compute reverse disparity")
 
     .def("compute_height_fwd", &BSGM_T::compute_height_fwd,
+         py::call_guard<py::gil_scoped_release>(),
          "compute forward height data (tri_3d, ptset, heightmap)")
     .def("compute_height_rev", &BSGM_T::compute_height_rev,
+         py::call_guard<py::gil_scoped_release>(),
          "compute reverse height data (tri_3d, ptset, heightmap)")
 
     .def("compute_prob", &BSGM_T::compute_prob,
+         py::call_guard<py::gil_scoped_release>(),
          "compute probabilistic height")
 
     .def("process", &BSGM_T::process,
+         py::call_guard<py::gil_scoped_release>(),
          py::arg("with_consistency_check") = true,
          "Main process method")
 


### PR DESCRIPTION
Update for `bsgm.prob_pairwise_dsm` binding:
- Add `py::gil_scoped_release` to long running computational processes (otherwise these processes are limited to a single thread - see issue #59)
- Add `radial_std_dev_image` accessor