### PR TITLE
pyvxl.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ function(pyvxl_add_module vxl_name)
     install(FILES __init__.py DESTINATION ${install_dir})
 
     # initialize target if necessary
-    if (EXISTS "${target_file_h}")
+    if (EXISTS "${target_file_cxx}")
         message(STATUS "pyvxl found ${target_name}")
 
         # Add pybind11 module

--- a/contrib/acal/pyacal.cxx
+++ b/contrib/acal/pyacal.cxx
@@ -23,12 +23,6 @@ namespace py = pybind11;
 
 namespace pyvxl { namespace acal {
 
-// simplify overload casting (C++11 version)
-// https://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods
-template <typename... Args>
-using overload_cast_ = py::detail::overload_cast_impl<Args...>;
-
-
 void wrap_acal(py::module &m)
 {
 

--- a/contrib/bsgm/pybsgm.cxx
+++ b/contrib/bsgm/pybsgm.cxx
@@ -13,12 +13,6 @@ namespace py = pybind11;
 
 namespace pyvxl { namespace bsgm {
 
-// simplify overload casting (C++11 version)
-// https://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods
-template <typename... Args>
-using overload_cast_ = py::detail::overload_cast_impl<Args...>;
-
-
 // wrapping for bsgm_prob_pairwise_dsm
 template<class CAM_T>
 void wrap_bsgm_prob_pairwise_dsm(py::module &m, std::string const& class_name)

--- a/pyvxl_util.h
+++ b/pyvxl_util.h
@@ -6,6 +6,14 @@
 #include <sstream>
 #include <vsl/vsl_binary_io.h>
 
+namespace pyvxl {
+
+// simplify overload casting (C++11 version)
+// https://pybind11.readthedocs.io/en/stable/classes.html#overloaded-methods
+template <typename... Args>
+using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
+
+
 // Return a string based on output of the object's stream operator
 template<typename T>
 std::string streamToString(T const& t){
@@ -137,5 +145,8 @@ T init_struct_from_kwargs(pybind11::kwargs kwargs)
   set_struct_from_kwargs<T>(self, kwargs);
   return self;
 }
+
+
+} // end namespace pyvxl
 
 #endif

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -45,10 +45,9 @@
 #include <array>
 #include <cmath>
 
-
 namespace py = pybind11;
 
-namespace pyvxl {
+namespace pyvxl { namespace vpgl {
 
 /* This is a "trampoline" helper class for the virtual vpgl_camera<double>
  * class, which redirects virtual calls back to Python */
@@ -893,11 +892,11 @@ void wrap_vpgl(py::module &m)
         py::arg("uncertainty"), py::arg("lvcs") = vpgl_lvcs());
 
 }
-}
+}}
 
 PYBIND11_MODULE(_vpgl, m)
 {
-  m.doc() =  "Python bindings for the VIL computer vision libraries";
+  m.doc() =  "Python bindings for the VPGL computer vision libraries";
 
-  pyvxl::wrap_vpgl(m);
+  pyvxl::vpgl::wrap_vpgl(m);
 }

--- a/vpgl/pyvpgl.h
+++ b/vpgl/pyvpgl.h
@@ -3,11 +3,11 @@
 
 #include <pybind11/pybind11.h>
 
-namespace pyvxl {
+namespace pyvxl { namespace vpgl {
 
 void wrap_vpgl(pybind11::module &m);
 
-}
+}}
 
 
 #endif


### PR DESCRIPTION
Add top-level `pyvxl.h` file.  This defines some basic stuff like `namespace py = pybind11;` and makes the c++11 compatible `overload_cast_` available to the entire pyvxl namespace.

Also adds a missing "vpgl" namespace.