### PR TITLE
Compile Fix

### DIFF
--- a/contrib/bsgm/pybsgm.cxx
+++ b/contrib/bsgm/pybsgm.cxx
@@ -140,6 +140,8 @@ void wrap_bsgm_prob_pairwise_dsm(py::module &m, std::string const& class_name)
     .def("process", &BSGM_T::process,
          py::call_guard<py::gil_scoped_release>(),
          py::arg("with_consistency_check") = true,
+         py::arg("knn_consistency") = true,
+         py::arg("compute_fwd_rev_ptsets_hmaps") = true,
          "Main process method")
 
     .def("save_prob_ptset_color", &BSGM_T::save_prob_ptset_color,


### PR DESCRIPTION
Fixed default arguments to bsgm_prob_pairwise_dsm::process, as they've changed w/ VXL PR #812. 