### PR TITLE
minor MSVC warnings

### DIFF
--- a/vgl/pyvgl.cxx
+++ b/vgl/pyvgl.cxx
@@ -197,7 +197,7 @@ typename vgl_polygon<T>::sheet_t getitem_sheet(vgl_polygon<T> const& p, long i){
   }
 
   // out of range
-  if(i < 0 || i >= p.num_sheets()){
+  if(i < 0 || (unsigned)i >= p.num_sheets()){
     throw py::index_error("index out of range");
   }
 
@@ -214,7 +214,7 @@ std::vector<std::vector<std::vector<T>>> vgl_polygon_as_array(vgl_polygon<T> con
   // return an array of lists of [x,y] points
   std::vector<std::vector<std::vector<T>>> array_of_sheets;
 
-  for (int i = 0; i < p.num_sheets(); ++i) {
+  for (size_t i = 0; i < p.num_sheets(); ++i) {
 
     // the vxl source sheet
     typename vgl_polygon<T>::sheet_t sheet = p[i];
@@ -476,7 +476,6 @@ std::vector<T> read_scalars_from_buffer(py::buffer b) {
 
   std::vector<T> scalars(num_rows);
   T* data_ptr = static_cast<T*>(info.ptr);
-  T* row_ptr;
   for (size_t i = 0; i < num_rows; ++i) {
     scalars[i] = *(data_ptr + (i * row_stride));
   }

--- a/vnl/pyvnl.cxx
+++ b/vnl/pyvnl.cxx
@@ -32,7 +32,7 @@ long _vnl_index(long i, unsigned int size)
   if (i < 0) {
     i += size;
   }
-  if ((i < 0) || (i >= size)) {
+  if ((i < 0) || ((unsigned)i >= size)) {
     throw py::index_error("index out of range");
   }
   return i;

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -145,7 +145,7 @@ py::array vpgl_project_buffer(T const& cam, py::buffer b){
     const size_t output_nextRow = out_info.strides[0] / sizeof(double);
     const size_t output_nextCol = out_info.strides[1] / sizeof(double);
 
-    for(size_t i = 0; i < info.shape[0]; ++i, data += nextRow, out_data += output_nextRow){
+    for(py::ssize_t i = 0; i < info.shape[0]; ++i, data += nextRow, out_data += output_nextRow){
         const double x = *data;
         const double y = *(data + nextCol);
         const double z = *(data + 2 * nextCol);


### PR DESCRIPTION
correct minor MSVC warnings in pyvgl, pyvnl, pyvpgl (e.g., signed/unsigned comparisons, unused variable).