### PR TITLE
bpgl_algo importlib

### DIFF
--- a/contrib/bpgl/algo/pybpgl_algo.cxx
+++ b/contrib/bpgl/algo/pybpgl_algo.cxx
@@ -11,6 +11,8 @@
 #include <array>
 
 #include <vgl/vgl_box_2d.h>
+#include <vil/vil_image_resource_sptr.h>
+#include <vil/vil_image_view.h>
 #include <vpgl/vpgl_affine_camera.h>
 #include <vpgl/vpgl_perspective_camera.h>
 #include <bpgl/algo/bpgl_heightmap_from_disparity.h>
@@ -85,6 +87,15 @@ void wrap_bpgl_algo(py::module &m)
 
 PYBIND11_MODULE(_bpgl_algo, m)
 {
+  // import dependencies for default arguments
+  py::module importlib_util = py::module::import("importlib.util");
+  std::string necessary_imports[] = {"vxl.vgl", "vxl.vil", "vxl.vpgl"};
+  for (const std::string &lib_str : necessary_imports) {
+    if (!importlib_util.attr("find_spec")(lib_str).is_none()) {
+      py::module::import(lib_str.c_str());
+    }
+  }
+
   m.doc() = "Python bindings for the VXL computer vision libraries";
 
   pyvxl::bpgl::algo::wrap_bpgl_algo(m);


### PR DESCRIPTION
Add importlib imports for vgl, vil, vpgl as these libraries are used in the arguments of functions within bpgl_algo. This resolves Issue #119, removing the need to first import vxl.vgl before importing vxl.contrib.bpgl.algo.