### PR TITLE
vpgl_trifocal_tensor

### DIFF
--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -447,6 +447,9 @@ void wrap_vpgl(py::module &m)
     .def("project", vpgl_project_xyz<vpgl_proj_camera<double> >)
     .def("project", vpgl_project_buffer<vpgl_proj_camera<double> >)
     .def("get_matrix", &vpgl_proj_camera<double>::get_matrix, py::return_value_policy::copy)
+    .def("set_matrix",
+        overload_cast_<vnl_matrix_fixed<double,3,4> const&>
+                      ()(&vpgl_proj_camera<double>::set_matrix))
     .def(py::self == py::self)
     .def(py::pickle(&vslPickleGetState<vpgl_proj_camera<double> >,
                     &vslPickleSetState<vpgl_proj_camera<double> >))


### PR DESCRIPTION
New bindings related to the trifocal tensor
- `vpgl_trifocal_tensor`
- `vpgl_affine_trifocal_tensor`
- `vpgl_fundamental_matrix`
- `vpgl_affine_fundamental_matrix`
- `vpgl_proj_camera::set_matrix`