### PR TITLE
PYTHON_SITE & CICD

### DIFF
--- a/.circleci/config.cmake
+++ b/.circleci/config.cmake
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)  # same as VXL
 project(pyvxl-circleci)
 
+# dependencies
 find_package(PythonLibs 3 REQUIRED)
 
+find_package(pybind11 REQUIRED)
+
+# source/binary directories
 set(VXL_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/vxl)
 set(VXL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/vxl)
-
-set(PYBIND11_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/pybind11)
-set(PYBIND11_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/pybind11)
 
 set(PYVXL_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/pyvxl)
 set(PYVXL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/pyvxl)
@@ -33,9 +34,6 @@ include_directories(${VXL_VCL_INCLUDE_DIR})
 include_directories(${VXL_DIR}/contrib/brl/bbas)
 include_directories(${VXL_DIR}/contrib/brl/bseg)
 include_directories(${VXL_DIR}/contrib/gel)
-
-# add pybind11
-add_subdirectory(${PYBIND11_SOURCE_DIR} ${PYBIND11_BINARY_DIR})
 
 # add pyvxl
 add_subdirectory(${PYVXL_SOURCE_DIR} ${PYVXL_BINARY_DIR})

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,42 @@ jobs:
       - run:
           name: Setup
           command: |
-            set -e
+
+            # clear the way
+            mkdir -p /source/vxl /source/pyvxl /build /venv
+
+            # system packages
             apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dev python3-pip
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+              python3-dev
+
+            # recent pip
+            curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+            python3 /tmp/get-pip.py
+
+            # system python packages
+            pip3 install virtualenv pybind11[global]
+
+            # create & activate venv
+            virtualenv /venv
+            source /venv/bin/activate
+
+            # add virtualenv to .bashrc to automatically activate
+            # for every following step
+            echo "source /venv/bin/activate" >> $BASH_ENV
+
+            # virtualenv packages
             pip3 install numpy
-            mkdir -p /build /install
-            mkdir -p /source/vxl /source/pybind11 /source/pyvxl
+
+            # report
+            set -x
+            type -a python3
+            python3 --version
+            python3 -m site
+            pip3 freeze --all
 
       - run:
-          name: Checkout VXL & pybind11
+          name: Checkout VXL
           command: |
 
             # clone vxl, optionally checkout specific version, report
@@ -26,21 +53,25 @@ jobs:
                 https://github.com/vxl/vxl.git "${VXL_DIR}"
             echo "git describe vxl = $(git -C "${VXL_DIR}" describe --tags HEAD --always)"
 
-            # clone pybind11, optionally checkout specific version, report
-            PYBIND11_DIR="/source/pybind11"
-            git clone -b "${PYBIND11_VERSION:-master}" \
-                https://github.com/pybind/pybind11.git "${PYBIND11_DIR}"
-            echo "git describe pybind11 = $(git -C "${PYBIND11_DIR}" describe --tags HEAD --always)"
-
       - checkout:
           path: /source/pyvxl
 
       - run:
-          name: cmake
+          name: configure
           working_directory: /build
           command: |
+
+            # top-level cmake file
             mv /source/pyvxl/.circleci/config.cmake /source/CMakeLists.txt
-            cmake -G Ninja /source -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/install -DPYVXL_CONTRIB_MAKE_ALL=ON
+
+            # configure
+            OPTS=(
+              -G Ninja
+              -D CMAKE_BUILD_TYPE=Release
+              -D PYVXL_CONTRIB_MAKE_ALL=ON
+              -D PYVXL_DEBUG_MESSAGES=ON
+            )
+            cmake /source ${OPTS[@]}
 
       - run:
           name: compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ function(pyvxl_add_module vxl_name)
     # install directory
     string(REPLACE
            "${PYVXL_PROJECT_SOURCE_DIR}" # string to be replaced
-           "${PYTHON_SITE}/vxl"          # replace with this
+           "${PYVXL_INSTALL_DIR}"          # replace with this
            install_dir                   # output
            "${CMAKE_CURRENT_SOURCE_DIR}" # input
            )
@@ -110,14 +110,25 @@ include_directories(${PYTHON_INCLUDE_PATH})
 
 include_directories(${PROJECT_SOURCE_DIR})
 
-# Find the python install directory
+# python site-packages directory reported by ``sysconfig.get_path('purelib')``
+# https://stackoverflow.com/a/46071447
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    from distutils import sysconfig as sc
-    print(sc.get_python_lib(plat_specific=True))"
+    import sysconfig
+    print(sysconfig.get_path('purelib'))"
   OUTPUT_VARIABLE PYTHON_SITE_DEFAULT
   OUTPUT_STRIP_TRAILING_WHITESPACE)
-set(PYTHON_SITE ${PYTHON_SITE_DEFAULT} CACHE STRING "Python installation directory")
+
+# python site-packages cache variable
+set(PYTHON_SITE "${PYTHON_SITE_DEFAULT}" CACHE STRING "Python site-packages directory")
+
+if ("${PYTHON_SITE}" STREQUAL "${PYTHON_SITE_DEFAULT}")
+  set(PYTHON_SITE_INITIALIZED_TO_DEFAULT 1)
+endif()
+
+# installation directory as sub-dir of PYTHON_SITE
+set(PYVXL_INSTALL_DIR "${PYTHON_SITE}/vxl")
+message(STATUS "pyvxl will be installed to ${PYVXL_INSTALL_DIR}")
 
 # add main module
 pyvxl_add_module(vxl)


### PR DESCRIPTION
1. change default `PYTHON_SITE` discovery to use sysconfig instead of distutils. distutils has been deprecated as of python 3.10 https://peps.python.org/pep-0632/

1. Refactor/fix CICD pipeline.
    - pybind11 from pypi
    - virtualenv
    - automated discovery of `PYTHON_SITE`
    - additional reporting