### PR TITLE
Vectorized LVCS functions

### DIFF
--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -459,6 +459,10 @@ class VpglLvcs(unittest.TestCase):
       point_range,
       indexing="xy"
     )
+    # slice and dice the inputs to test non-contiguous arrays w/differing strides
+    X = X[0:5, 5:10, ::2]
+    Y = Y[5:10, ::2, 0:5]
+    Z = Z[::2, 0:5, 5:10]
     for lvcs, cs_name in self.lvcs_cs_combos:
       loop_results = ([], [], [])
       for x, y, z in zip(X.flat, Y.flat, Z.flat):
@@ -497,6 +501,10 @@ class VpglLvcs(unittest.TestCase):
     for lvcs, cs_name in self.lvcs_cs_combos:
       # transform local grid of points to global coordinates for input
       GX, GY, GZ = lvcs.local_to_global(X, Y, Z, cs_name)
+      # slice and dice the inputs to test non-contiguous arrays w/differing strides
+      GX = GX[0:5, 5:10, ::2]
+      GY = GY[5:10, ::2, 0:5]
+      GZ = GZ[::2, 0:5, 5:10]
       loop_results = ([], [], [])
       for gx, gy, gz in zip(GX.flat, GY.flat, GZ.flat):
         x, y, z = lvcs.global_to_local(gx, gy, gz, cs_name)

--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -406,6 +406,115 @@ class VpglRationalCamera(VpglCameraBase, unittest.TestCase):
 
 
 # ----------
+# LVCS TESTS
+# ----------
+class VpglLvcs(unittest.TestCase):
+  """
+  Ensure local->global->local results in no change to point.
+  """
+
+  def __init__(self, *args, **kwargs):
+    self.origin = (-71.4193,  41.8286, 14.0)
+    # test both WGS84 and UTM variants
+    self.lvcs_cs_combos = [
+      (vpgl.lvcs(*self.origin, vpgl.lvcs.cs_names.wgs84), vpgl.lvcs.cs_names.wgs84),
+      (vpgl.lvcs(*self.origin, vpgl.lvcs.cs_names.utm), vpgl.lvcs.cs_names.utm),
+      (vpgl.lvcs(*self.origin, vpgl.lvcs.cs_names.utm), vpgl.lvcs.cs_names.wgs84),
+    ]
+    super().__init__(*args, **kwargs)
+
+  def test_roundtrip(self):
+    for lvcs, cs_name in self.lvcs_cs_combos:
+      # test a single point
+      point_local = (100.0, -100.0, 25.0)
+      point_global = lvcs.local_to_global(*point_local, cs_name)
+      point_local_rt = lvcs.global_to_local(*point_global, cs_name)
+      np.testing.assert_allclose(point_local, point_local_rt, atol=0.01, err_msg=f"Round trip failed for {lvcs} with {cs_name}")
+
+  def test_vectorized_roundtrip(self):
+    for lvcs, cs_name in self.lvcs_cs_combos:
+      # test an array of points
+      num_points = 10
+      points_local = (
+        np.linspace(-100, 100, num_points),
+        np.linspace(-50, 50, num_points),
+        np.linspace(-5, 5, num_points)
+      )
+      points_global = lvcs.local_to_global(points_local[0], points_local[1], points_local[2], cs_name)
+      points_local_rt = lvcs.global_to_local(points_global[0], points_global[1], points_global[2], cs_name)
+      np.testing.assert_allclose(points_local, points_local_rt, atol=0.01, err_msg=f"Round trip failed for vectorized {lvcs} with {cs_name}.")
+
+
+  def test_vectorized_local_to_global(self):
+    """
+    Ensure vectorized versions of local_to_global() has same behavior as non-vectorized version.
+    """
+    point_range = np.linspace(-500, 500, 10)
+    X, Y, Z = np.meshgrid(
+      point_range,
+      point_range,
+      point_range,
+      indexing="xy"
+    )
+    for lvcs, cs_name in self.lvcs_cs_combos:
+      loop_results = ([], [], [])
+      for x, y, z in zip(X.flat, Y.flat, Z.flat):
+        lon, lat, el = lvcs.local_to_global(x, y, z, cs_name)
+        loop_results[0].append(lon)
+        loop_results[1].append(lat)
+        loop_results[2].append(el)
+
+      vectorized_results = lvcs.local_to_global(X, Y, Z, cs_name)
+      # vectorized call should return (lon, lat, el) or (easting, northing, el)
+      self.assertEqual(len(vectorized_results), 3)
+      # vectorized result should be same shape as inputs
+      for vr in vectorized_results:
+        self.assertEqual(vr.shape, X.shape)
+      # vectorized results should equal looped results
+      for d in range(3):
+        np.testing.assert_allclose(
+          loop_results[d],
+          vectorized_results[d].flat,
+          err_msg=f"vectorized and looped result mismatch for {lvcs} with {cs_name}, dim {d}"
+        )
+
+  def test_vectorized_global_to_local(self):
+    """
+    Ensure vectorized versions of global_to_local() has same behavior as non-vectorized version.
+    """
+    # start with a grid of local points, and transform to global
+    point_range = np.linspace(-500, 500, 10)
+    X, Y, Z = np.meshgrid(
+      point_range,
+      point_range,
+      point_range,
+      indexing="xy"
+    )
+    for lvcs, cs_name in self.lvcs_cs_combos:
+      # transform local grid of points to global coordinates for input
+      GX, GY, GZ = lvcs.local_to_global(X, Y, Z, cs_name)
+      loop_results = ([], [], [])
+      for gx, gy, gz in zip(GX.flat, GY.flat, GZ.flat):
+        x, y, z = lvcs.global_to_local(gx, gy, gz, cs_name)
+        loop_results[0].append(x)
+        loop_results[1].append(y)
+        loop_results[2].append(z)
+
+      vectorized_results = lvcs.global_to_local(GX, GY, GZ, cs_name)
+      # vectorized call should return X,Y,Z tuple
+      self.assertEqual(len(vectorized_results), 3)
+      # vectorized result should be same shape as inputs
+      for vr in vectorized_results:
+        self.assertEqual(vr.shape, GX.shape)
+      # vectorized results should equal looped results
+      for d in range(3):
+        np.testing.assert_allclose(
+          loop_results[d],
+          vectorized_results[d].flat,
+          err_msg=f"vectorized and looped result mismatch for {lvcs} with {cs_name}, dim {d}"
+        )
+
+# ----------
 # OTHER TESTS
 # ----------
 

--- a/test/test_pyvpgl.py
+++ b/test/test_pyvpgl.py
@@ -423,6 +423,7 @@ class VpglLvcs(unittest.TestCase):
     ]
     super().__init__(*args, **kwargs)
 
+  @unittest.skipUnless(np, "Numpy not found")
   def test_roundtrip(self):
     for lvcs, cs_name in self.lvcs_cs_combos:
       # test a single point
@@ -431,6 +432,7 @@ class VpglLvcs(unittest.TestCase):
       point_local_rt = lvcs.global_to_local(*point_global, cs_name)
       np.testing.assert_allclose(point_local, point_local_rt, atol=0.01, err_msg=f"Round trip failed for {lvcs} with {cs_name}")
 
+  @unittest.skipUnless(np, "Numpy not found")
   def test_vectorized_roundtrip(self):
     for lvcs, cs_name in self.lvcs_cs_combos:
       # test an array of points
@@ -445,6 +447,7 @@ class VpglLvcs(unittest.TestCase):
       np.testing.assert_allclose(points_local, points_local_rt, atol=0.01, err_msg=f"Round trip failed for vectorized {lvcs} with {cs_name}.")
 
 
+  @unittest.skipUnless(np, "Numpy not found")
   def test_vectorized_local_to_global(self):
     """
     Ensure vectorized versions of local_to_global() has same behavior as non-vectorized version.
@@ -478,6 +481,7 @@ class VpglLvcs(unittest.TestCase):
           err_msg=f"vectorized and looped result mismatch for {lvcs} with {cs_name}, dim {d}"
         )
 
+  @unittest.skipUnless(np, "Numpy not found")
   def test_vectorized_global_to_local(self):
     """
     Ensure vectorized versions of global_to_local() has same behavior as non-vectorized version.

--- a/vpgl/__init__.py
+++ b/vpgl/__init__.py
@@ -285,8 +285,8 @@ def lvcs_global_to_local(self, global_longitude, global_latitude, global_elevati
   global_longitude : double or array_like
     longitude or easting in global coordinate system 
 
-  global_lattitude: double or array_like
-    lattitude or northing in global coordinate system
+  global_latitude: double or array_like
+    latitude or northing in global coordinate system
 
   global_elevation: double or array_like
     elevation in global coordinate system
@@ -304,7 +304,6 @@ def lvcs_global_to_local(self, global_longitude, global_latitude, global_elevati
   -------
   tuple containing (x,y,z) local coordinates
   """
-  from ._vpgl import lvcs
   result = self._global_to_local(global_longitude, global_latitude, global_elevation, input_cs_name, input_ang_unit, input_len_unit)
   if np and isinstance(result, np.ndarray):
     # vectorized version was called. unpack results into a tuple of lon, lat, el
@@ -344,7 +343,6 @@ def lvcs_local_to_global(self, local_x, local_y, local_z, output_cs_name, output
   -------
   tuple containing (lon, lat, el) or (easting, northing, el) global coordinates
   """
-  from ._vpgl import lvcs
   result = self._local_to_global(local_x, local_y, local_z, output_cs_name, output_ang_unit, output_len_unit)
   if np and isinstance(result, np.ndarray):
     # vectorized version was called. unpack results into a tuple of lon, lat, el

--- a/vpgl/__init__.py
+++ b/vpgl/__init__.py
@@ -1,6 +1,9 @@
 from ._vpgl import *
 from vxl import vgl, vnl
-import numpy as np
+try:
+  import numpy as np
+except:
+  np = None
 
 
 def load_rational_camera(cam_fname):
@@ -274,9 +277,36 @@ rsm_metadata.as_dict_validated = lambda x: _rsm_metadata_validate_dict(x.as_dict
 
 
 def lvcs_global_to_local(self, global_longitude, global_latitude, global_elevation, input_cs_name, input_ang_unit=lvcs.AngUnits.DEG, input_len_unit=lvcs.LenUnits.METERS):
+  """
+  Convert global (lon, lat, el) or (easting, northing, el) coordinates to local (x, y, z) coordinates.
+
+  Parameters
+  ----------
+  global_longitude : double or array_like
+    longitude or easting in global coordinate system 
+
+  global_lattitude: double or array_like
+    lattitude or northing in global coordinate system
+
+  global_elevation: double or array_like
+    elevation in global coordinate system
+
+  input_cs_name: vxl.vpgl.cs_names
+    global coordinate system of input coordinates
+
+  input_ang_unit: vxl.vpgl.AngUnits, optional
+    angular units (DEG or RADIANS) of input coordinates (geodetic)
+
+  input_len_unit: vxl.vpgl.LenUnits, optional
+    metric units (FEET or METERS) of input coordinates (utm)
+
+  Returns
+  -------
+  tuple containing (x,y,z) local coordinates
+  """
   from ._vpgl import lvcs
   result = self._global_to_local(global_longitude, global_latitude, global_elevation, input_cs_name, input_ang_unit, input_len_unit)
-  if isinstance(result, np.ndarray):
+  if np and isinstance(result, np.ndarray):
     # vectorized version was called. unpack results into a tuple of lon, lat, el
     result = np.frombuffer(result.tobytes(), result.dtype[0]).reshape(result.shape+(3,))
     # seperate into tuple of arrays for API consistency
@@ -287,9 +317,36 @@ lvcs.global_to_local = lvcs_global_to_local
 
 
 def lvcs_local_to_global(self, local_x, local_y, local_z, output_cs_name, output_ang_unit=lvcs.AngUnits.DEG, output_len_unit=lvcs.LenUnits.METERS):
+  """
+  Convert local (x, y, z) coordinates to global (lon, lat, el) or (easting, northing, el) coordinates.
+
+  Parameters
+  ----------
+  local_x : double or array_like
+    x coordinate in the local coordinate system
+
+  local_y: double or array_like
+    y coordinate in the local coordinate system
+
+  local_z: double or array_like
+    z coordinate in the local coordinate system
+
+  output_cs_name: vxl.vpgl.cs_names
+    global coordinate system of output coordinates
+
+  output_ang_unit: vxl.vpgl.AngUnits, optional
+    angular units (DEG or RADIANS) of output global coordinates (geodetic)
+
+  output_len_unit: vxl.vpgl.LenUnits, optional
+    metric units (FEET or METERS) of output global coordinates (utm)
+
+  Returns
+  -------
+  tuple containing (lon, lat, el) or (easting, northing, el) global coordinates
+  """
   from ._vpgl import lvcs
   result = self._local_to_global(local_x, local_y, local_z, output_cs_name, output_ang_unit, output_len_unit)
-  if isinstance(result, np.ndarray):
+  if np and isinstance(result, np.ndarray):
     # vectorized version was called. unpack results into a tuple of lon, lat, el
     result = np.frombuffer(result.tobytes(), result.dtype[0]).reshape(result.shape+(3,))
     # seperate into tuple of arrays for API consistency

--- a/vpgl/__init__.py
+++ b/vpgl/__init__.py
@@ -1,5 +1,6 @@
 from ._vpgl import *
 from vxl import vgl, vnl
+import numpy as np
 
 
 def load_rational_camera(cam_fname):
@@ -270,3 +271,29 @@ def _rsm_metadata_validate_dict(dct):
 
 # add ``as_dict_validated`` method to rsm_metadata object
 rsm_metadata.as_dict_validated = lambda x: _rsm_metadata_validate_dict(x.as_dict())
+
+
+def lvcs_global_to_local(self, global_longitude, global_latitude, global_elevation, input_cs_name, input_ang_unit=lvcs.AngUnits.DEG, input_len_unit=lvcs.LenUnits.METERS):
+  from ._vpgl import lvcs
+  result = self._global_to_local(global_longitude, global_latitude, global_elevation, input_cs_name, input_ang_unit, input_len_unit)
+  if isinstance(result, np.ndarray):
+    # vectorized version was called. unpack results into a tuple of lon, lat, el
+    result = np.frombuffer(result.tobytes(), result.dtype[0]).reshape(result.shape+(3,))
+    # seperate into tuple of arrays for API consistency
+    result = (result[..., 0], result[..., 1], result[..., 2])
+  return result
+
+lvcs.global_to_local = lvcs_global_to_local
+
+
+def lvcs_local_to_global(self, local_x, local_y, local_z, output_cs_name, output_ang_unit=lvcs.AngUnits.DEG, output_len_unit=lvcs.LenUnits.METERS):
+  from ._vpgl import lvcs
+  result = self._local_to_global(local_x, local_y, local_z, output_cs_name, output_ang_unit, output_len_unit)
+  if isinstance(result, np.ndarray):
+    # vectorized version was called. unpack results into a tuple of lon, lat, el
+    result = np.frombuffer(result.tobytes(), result.dtype[0]).reshape(result.shape+(3,))
+    # seperate into tuple of arrays for API consistency
+    result = (result[..., 0], result[..., 1], result[..., 2])
+  return result
+
+lvcs.local_to_global = lvcs_local_to_global

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -889,9 +889,7 @@ void wrap_vpgl_affine_tri_focal_tensor(py::module &m, const char* name)
 }
 
 struct double3 {
-  double v0;
-  double v1;
-  double v2;
+  std::array<double, 3> value;
 };
 
 double3 lvcs_global_to_local_wrapper(
@@ -901,7 +899,7 @@ double3 lvcs_global_to_local_wrapper(
   )
 {
     double3 result;
-    lvcs.global_to_local(lon, lat, el, ics, result.v0, result.v1, result.v2, iau, ilu);
+    lvcs.global_to_local(lon, lat, el, ics, result.value[0], result.value[1], result.value[2], iau, ilu);
     return result;
 }
 
@@ -912,7 +910,7 @@ double3 lvcs_local_to_global_wrapper(
   )
 {
     double3 result;
-    lvcs.local_to_global(x, y, z, ocs, result.v0, result.v1, result.v2, oau, olu);
+    lvcs.local_to_global(x, y, z, ocs, result.value[0], result.value[1], result.value[2], oau, olu);
     return result;
 }
 
@@ -1637,5 +1635,5 @@ PYBIND11_MODULE(_vpgl, m)
 
   pyvxl::vpgl::wrap_vpgl(m);
   // required for return types of lvcs _global_to_local and _local_to_global
-  PYBIND11_NUMPY_DTYPE(pyvxl::vpgl::double3, v0, v1, v2);
+  PYBIND11_NUMPY_DTYPE(pyvxl::vpgl::double3, value);
 }

--- a/vpgl/pyvpgl.cxx
+++ b/vpgl/pyvpgl.cxx
@@ -888,159 +888,85 @@ void wrap_vpgl_affine_tri_focal_tensor(py::module &m, const char* name)
     ;
 }
 
-  std::tuple<py::array, py::array, py::array> lvcs_global_to_local_buffer(
-    vpgl_lvcs & lvcs, py::buffer lon, py::buffer lat, py::buffer el,
+std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>> lvcs_global_to_local_array(
+    vpgl_lvcs & lvcs, py::array_t<double> lon, py::array_t<double> lat, py::array_t<double> el,
     vpgl_lvcs::cs_names const ics, vpgl_lvcs::AngUnits const iau,
     vpgl_lvcs::LenUnits const ilu
   )
 {
-    py::buffer_info lon_info = lon.request();
-    auto format = lon_info.format;
-    if (format != py::format_descriptor<double>::value) {
-      throw std::runtime_error("Incompatible scalar type; Expecting double");
-    }
-    auto ndim = lon_info.ndim;
-    auto shape = lon_info.shape;
-    auto strides = lon_info.strides;
+    const py::ssize_t size = lon.size();
+    const py::ssize_t ndim = lon.ndim();
+    const py::ssize_t* shape = lon.shape();
+    const py::ssize_t* strides = lon.strides();
 
-    auto lat_info = lat.request();
-    auto el_info = el.request();
-    if ((lat_info.format != format) || (el_info.format != format)) {
-      throw std::runtime_error("Arguments must have same datatype");
-    }
-    if ((lat_info.ndim != ndim) || (el_info.ndim != ndim)) {
-      throw std::runtime_error("Arguments must have same number of dimensions");
-    }
-    if ((lat_info.shape != shape) || (el_info.shape != shape)) {
-      throw std::runtime_error("Arguments must have same shape");
-    }
-    if ((lat_info.strides != strides) || (el_info.strides != strides)) {
-      // this is required so we can loop through the flattened arrays in sync
-      throw std::runtime_error("Arguments must have same strides");
+    for(auto i=0; i<ndim; ++i) {
+      if ((shape[i] != lat.shape()[i]) || (shape[i] != el.shape()[i])) {
+        throw std::runtime_error("Arguments must have same shape");
+      }
+      if ((strides[i] != lat.strides()[i]) || (strides[i] != el.strides()[i])) {
+        // Identical strides are required for synced traversal of arrays
+        throw std::runtime_error("Arguments must have same strides");
+      }
     }
 
-    double const *lon_data = static_cast<double const *>(lon_info.ptr);
-    double const *lat_data = static_cast<double const *>(lat_info.ptr);
-    double const *el_data = static_cast<double const *>(el_info.ptr);
+    std::vector<py::ssize_t> shape_v(shape, shape + ndim);
+    py::array_t<double> output_x(shape_v);
+    py::array_t<double> output_y(shape_v);
+    py::array_t<double> output_z(shape_v);
 
-    py::array output_x = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      lon_info.strides));
-    py::array output_y = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      lon_info.strides));
-    py::array output_z = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      lon_info.strides));
-    py::buffer_info x_info = output_x.request();
-    py::buffer_info y_info = output_y.request();
-    py::buffer_info z_info = output_z.request();
-    double *x_data = static_cast<double *>(x_info.ptr);
-    double *y_data = static_cast<double *>(y_info.ptr);
-    double *z_data = static_cast<double *>(z_info.ptr);
+    double const *lon_data = static_cast<double const*>(lon.request().ptr);
+    double const *lat_data = static_cast<double const*>(lat.request().ptr);
+    double const *el_data = static_cast<double const*>(el.request().ptr);
 
-    for (py::ssize_t i = 0; i < lat_info.size; ++i) {
-      const double lon_val = *(lon_data + i);
-      const double lat_val = *(lat_data + i);
-      const double el_val = *(el_data + i);
-      double x, y, z;
-      lvcs.global_to_local(lon_val, lat_val, el_val, ics, x, y, z, iau, ilu);
-      *(x_data + i) = x;
-      *(y_data + i) = y;
-      *(z_data + i) = z;
+    double *x_data = static_cast<double *>(output_x.request().ptr);
+    double *y_data = static_cast<double *>(output_y.request().ptr);
+    double *z_data = static_cast<double *>(output_z.request().ptr);
+
+    for (py::ssize_t i = 0; i < size; ++i) {
+      lvcs.global_to_local(lon_data[i], lat_data[i], el_data[i], ics, x_data[i], y_data[i], z_data[i], iau, ilu);
     }
     return std::make_tuple(output_x, output_y, output_z);
 }
 
-std::tuple<py::array, py::array, py::array> lvcs_local_to_global_buffer(
-    vpgl_lvcs & lvcs, py::buffer x, py::buffer y, py::buffer z,
+std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>> lvcs_local_to_global_array(
+    vpgl_lvcs & lvcs, py::array_t<double> x, py::array_t<double> y, py::array_t<double> z,
     vpgl_lvcs::cs_names const ocs, vpgl_lvcs::AngUnits const oau,
     vpgl_lvcs::LenUnits const olu
   )
 {
-    py::buffer_info x_info = x.request();
-    auto format = x_info.format;
-    if (format != py::format_descriptor<double>::value) {
-      throw std::runtime_error("Incompatible scalar type; Expecting double");
-    }
-    auto ndim = x_info.ndim;
-    auto shape = x_info.shape;
-    auto strides = x_info.strides;
+    const py::ssize_t size = x.size();
+    const py::ssize_t ndim = x.ndim();
+    const py::ssize_t* shape = x.shape();
+    const py::ssize_t* strides = x.strides();
 
-    auto y_info = y.request();
-    auto z_info = z.request();
-    if ((y_info.format != format) || (z_info.format != format)) {
-      throw std::runtime_error("Arguments must have same datatype");
-    }
-    if ((y_info.ndim != ndim) || (z_info.ndim != ndim)) {
-      throw std::runtime_error("Arguments must have same number of dimensions");
-    }
-    if ((y_info.shape != shape) || (z_info.shape != shape)) {
-      throw std::runtime_error("Arguments must have same shape");
-    }
-    if ((y_info.strides != strides) || (z_info.strides != strides)) {
-      // this is required so we can loop through the fytened arrays in sync
-      throw std::runtime_error("Arguments must have same strides");
+    for(auto i=0; i<ndim; ++i) {
+      if ((shape[i] != y.shape()[i]) || (shape[i] != z.shape()[i])) {
+        throw std::runtime_error("Arguments must have same shape");
+      }
+      if ((strides[i] != y.strides()[i]) || (strides[i] != z.strides()[i])) {
+        // Identical strides are required for synced traversal of arrays
+        throw std::runtime_error("Arguments must have same strides");
+      }
     }
 
-    double const *x_data = static_cast<double const *>(x_info.ptr);
-    double const *y_data = static_cast<double const *>(y_info.ptr);
-    double const *z_data = static_cast<double const *>(z_info.ptr);
+    std::vector<py::ssize_t> shape_v(shape, shape + ndim);
+    py::array_t<double> output_lon(shape_v);
+    py::array_t<double> output_lat(shape_v);
+    py::array_t<double> output_el(shape_v);
 
-    py::array output_lon = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      strides));
-    py::array output_lat = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      strides));
-    py::array output_el = py::array(py::buffer_info(
-      (void *)nullptr,                      /* Numpy allocates */
-      sizeof(double),                       /* Size of one item */
-      py::format_descriptor<double>::value, /* Buffer format */
-      ndim,                                 /* Number of dimensions */
-      shape, /* Number of elements in each dimension */
-      strides));
-    py::buffer_info lon_info = output_lon.request();
-    py::buffer_info lat_info = output_lat.request();
-    py::buffer_info el_info = output_el.request();
-    double *lon_data = static_cast<double *>(lon_info.ptr);
-    double *lat_data = static_cast<double *>(lat_info.ptr);
-    double *el_data = static_cast<double *>(el_info.ptr);
+    double const *x_data = static_cast<double const*>(x.request().ptr);
+    double const *y_data = static_cast<double const*>(y.request().ptr);
+    double const *z_data = static_cast<double const*>(z.request().ptr);
 
-    for (py::ssize_t i = 0; i < lon_info.size; ++i) {
-      const double xval = *(x_data + i);
-      const double yval = *(y_data + i);
-      const double zval = *(z_data + i);
-      double lon, lat, el;
-      lvcs.local_to_global(xval, yval, zval, ocs, lon, lat, el, oau, olu);
-      *(lon_data + i) = lon;
-      *(lat_data + i) = lat;
-      *(el_data + i) = el;
+    double *lon_data = static_cast<double *>(output_lon.request().ptr);
+    double *lat_data = static_cast<double *>(output_lat.request().ptr);
+    double *el_data = static_cast<double *>(output_el.request().ptr);
+
+    for (py::ssize_t i = 0; i < size; ++i) {
+      lvcs.local_to_global(x_data[i], y_data[i], z_data[i], ocs, lon_data[i], lat_data[i], el_data[i], oau, olu);
     }
     return std::make_tuple(output_lon, output_lat, output_el);
 }
-
-
 
 void wrap_vpgl(py::module &m)
 {
@@ -1487,7 +1413,7 @@ void wrap_vpgl(py::module &m)
         py::arg("output_cs_name"),py::arg("output_ang_unit")=vpgl_lvcs::DEG,
         py::arg("output_len_unit")=vpgl_lvcs::METERS
      )
-     .def("local_to_global", lvcs_local_to_global_buffer,
+     .def("local_to_global", lvcs_local_to_global_array,
         py::arg("local_x"),py::arg("local_y"),py::arg("local_z"),
         py::arg("output_cs_name"),py::arg("output_ang_unit")=vpgl_lvcs::DEG,
         py::arg("output_len_unit")=vpgl_lvcs::METERS
@@ -1507,7 +1433,7 @@ void wrap_vpgl(py::module &m)
         py::arg("input_cs_name"),py::arg("input_ang_unit")=vpgl_lvcs::DEG,
         py::arg("input_len_unit")=vpgl_lvcs::METERS
      )
-     .def("global_to_local", lvcs_global_to_local_buffer,
+     .def("global_to_local", lvcs_global_to_local_array,
           py::arg("global_longitude"),py::arg("global_latitude"),py::arg("global_elevation"),
           py::arg("input_cs_name"),py::arg("input_ang_unit")=vpgl_lvcs::DEG,
           py::arg("input_len_unit")=vpgl_lvcs::METERS


### PR DESCRIPTION
- Add overloads of `lvcs.global_to_local()` and `lvcs.local_to_global()` that accept numpy arrays as input.
  The numpy versions have the same signature as the standard versions, i.e. you pass numpy arrays for x, y, and z and lon, lat, el as seperate arguments.  The arrays can have arbitrary shape, as long as they are the same for all arguments.

- Add test cases for `vpgl.lvcs`
