### PR TITLE
vil.load convert_cast

### DIFF
--- a/test/test_vil.py
+++ b/test/test_vil.py
@@ -1,0 +1,159 @@
+import os
+import unittest
+import utils
+import uuid
+
+try:
+  import numpy as np
+except:
+  np = None
+
+from vxl import vil
+
+class VilFile(utils.VxlBase, unittest.TestCase):
+
+
+  @staticmethod
+  def _image_gradient(shape):
+    ''' Generate gradient image'''
+    bands = list()
+    for i in range(shape[2]):
+      if i % 2:
+        band = np.tile(np.linspace(0, 1, shape[1]), (shape[0], 1))
+      else:
+        band = np.tile(np.linspace(0, 1, shape[0]), (shape[1], 1)).T
+      bands.append(band)
+    return np.dstack(bands).squeeze()
+
+
+  def _test_save_load(self, vil_type='byte', load_type=None, ext='.tif',
+                      nbands=1, rng=None, atol=1):
+    '''
+    vil.save followed by vil.load
+
+    Parameters
+    ----------
+    self
+      This object
+    vil_type
+      Type of vil object to save
+    load_type
+      Type of vil object to load, if different from the save type
+    ext
+      Output extension
+    nbands
+      Number of output bands/channels
+    rng
+      Output range ``[min, max]``
+    atol
+      Absolute tolerance for ``numpy.testing.assert_allclose``
+    '''
+
+    # default load type
+    if load_type is None:
+      load_type = vil_type
+
+    # numpy dtype for save
+    dtype_mapping = {
+      'byte': np.uint8,
+      'short': np.uint16,
+      'float': np.float32,
+      'int': np.int32,
+    }
+    dtype = dtype_mapping[vil_type]
+
+    # default range
+    if rng is None:
+      if np.issubdtype(dtype, np.integer):
+        iinfo = np.iinfo(dtype)
+        rng = [iinfo.min, iinfo.max]
+      else:
+        rng = [0.0, 255.0]
+
+    # create floating point image on range [0, 1]
+    shape = (256, 256, nbands)
+    image = self._image_gradient(shape)
+
+    # stretch to rng
+    image = (image * (rng[1] - rng[0])) + rng[0]
+
+    # vil.image_view_*
+    vil_func_mapping = {
+      'byte': vil.image_view_byte,
+      'short': vil.image_view_uint16,
+      'float': vil.image_view_float,
+      'int': vil.image_view_int,
+    }
+    vil_func = vil_func_mapping[vil_type]
+    view = vil_func(image)
+
+    # save to file
+    basename = f'{vil_type}_{nbands}band_{uuid.uuid4()}{ext}'
+    file = os.path.join(self.temp_dir.name, basename)
+
+    # save to file
+    vil.save_image_view(view, file)
+    if not os.path.exists(file):
+      raise AssertionError('File was not saved')
+
+    # load from file
+    view_load = vil.load(file, load_type)
+    image_load = np.array(view_load)
+
+    # check loaded dtype
+    _dtype = dtype_mapping[load_type]
+    self.assertEqual(image_load.dtype, _dtype,
+                     f"vil.load is not expected dtype={_dtype.__name__}")
+
+    # compare loaded values
+    np.testing.assert_allclose(image, image_load, rtol=0, atol=atol)
+
+
+  @unittest.skipUnless(np, 'Numpy not found')
+  def test_save_load(self):
+    '''Test various vil.save/vil.load combinations'''
+    data = [
+      # TIFF
+      {'ext': '.tif', 'vil_type': 'byte', 'nbands': 1},
+      {'ext': '.tif', 'vil_type': 'byte', 'nbands': 3},
+
+      {'ext': '.tif', 'vil_type': 'short', 'nbands': 1},
+      {'ext': '.tif', 'vil_type': 'short', 'nbands': 3},
+
+      {'ext': '.tif', 'vil_type': 'float', 'nbands': 1},
+      {'ext': '.tif', 'vil_type': 'float', 'nbands': 3},
+
+      # PNG
+      {'ext': '.png', 'vil_type': 'byte', 'nbands': 1},
+      {'ext': '.png', 'vil_type': 'byte', 'nbands': 3},
+
+      {'ext': '.png', 'vil_type': 'short', 'nbands': 1},
+      {'ext': '.png', 'vil_type': 'short', 'nbands': 3},
+
+      # JPEG (increase atol for lossy compression)
+      {'ext': '.jpg', 'vil_type': 'byte', 'nbands': 1, 'atol': 5},
+      {'ext': '.jpg', 'vil_type': 'byte', 'nbands': 3, 'atol': 5},
+
+      # Save as one type, load as another
+      {'vil_type': 'byte', 'load_type': 'short'},
+      {'vil_type': 'byte', 'load_type': 'float'},
+
+      {'vil_type': 'short', 'load_type': 'byte', 'rng': [0, 255]},
+      {'vil_type': 'short', 'load_type': 'float'},
+
+      {'vil_type': 'float', 'load_type': 'byte', 'rng': [0, 255]},
+      {'vil_type': 'float', 'load_type': 'short', 'rng': [0, 65535]},
+    ]
+
+    for item in data:
+      with self.subTest(item):
+        self._test_save_load(**item)
+
+
+  def test_load_no_file(self):
+    '''Raise an exception when loading a file that does not exist'''
+
+    vil_types = ('byte', 'short', 'float', 'int')
+    for vil_type in vil_types:
+      with self.subTest(vil_type), self.assertRaises(RuntimeError):
+        _ = vil.load('/not/a/file', vil_type)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,6 @@
 import collections.abc
 import math
+import tempfile
 
 # nested dictionary update
 def update_nested_dict(d, u):
@@ -19,6 +20,28 @@ def safe_isnan(val):
 
 # generic base unittest object
 class VxlBase(object):
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self._temp_dir = None
+
+  @property
+  def temp_dir(self):
+    '''
+    Automatically creates a temporary directory for any unittest that needs it
+
+    Cleanups automatically in :func:`tearDown`
+    '''
+    if self._temp_dir is None:
+      self._temp_dir = tempfile.TemporaryDirectory()
+    return self._temp_dir
+
+  def tearDown(self):
+    '''
+    Cleanup ``self.temp_dir`` if it exists
+    '''
+    if self._temp_dir is not None:
+      self._temp_dir.cleanup()
 
   # check for attribute
   def assertHasAttr(self, obj, attr, msg = None):

--- a/vil/pyvil.cxx
+++ b/vil/pyvil.cxx
@@ -359,22 +359,34 @@ void wrap_vil_image_view(py::module &m, std::string const& class_name)
 
 vil_image_view<unsigned char> load_byte(std::string filename)
 {
-  return vil_convert_stretch_range(vxl_byte(), vil_load(filename.c_str()));
+  auto view = vil_convert_cast(vxl_byte(), vil_load(filename.c_str()));
+  if (!view)
+    throw std::runtime_error("Failed to load byte image " + filename);
+  return view;
 }
 
 vil_image_view<unsigned short int> load_short(std::string filename)
 {
-  return vil_convert_stretch_range(vxl_uint_16(), vil_load(filename.c_str()));
+  auto view = vil_convert_cast(vxl_uint_16(), vil_load(filename.c_str()));
+  if (!view)
+    throw std::runtime_error("Failed to load short image " + filename);
+  return view;
 }
 
 vil_image_view<float> load_float(std::string filename)
 {
-  return vil_convert_stretch_range(float(), vil_load(filename.c_str()));
+  auto view = vil_convert_cast(float(), vil_load(filename.c_str()));
+  if (!view)
+    throw std::runtime_error("Failed to load float image " + filename);
+  return view;
 }
 
 vil_image_view<int> load_int(std::string filename)
 {
-  return vil_convert_stretch_range(int(), vil_load(filename.c_str()));
+  auto view = vil_convert_cast(int(), vil_load(filename.c_str()));
+  if (!view)
+    throw std::runtime_error("Failed to load int image " + filename);
+  return view;
 }
 
 vil_image_resource_sptr vil_load_image_resource_wrapper(std::string const& filename)


### PR DESCRIPTION
### Summary
`vil.load` use `convert_cast` to convert to other formats.  Add unit tests.

### Description

`vil.load` was previously using `vil_convert_stretch_range` to load images and convert to different data types. 

https://github.com/vxl/vxl/blob/c6c899aaf9cbf7ccabfca1ba35b2248fb611ffbc/core/vil/vil_convert.h#L1246-L1257

This had unintended consequences for some load requests.  For example, loading a float image would unexpectedly normalize the image on the range [0,1] rather than returning the original floating point values.

This PR adjusts `vil.load` to instead use `vil_convert_cast`, ensuring the original pixel data is read unchanged.  `vil.load` will further throw an exception if the image failed to load.

Added a variety of unit tests to validate `vil.save` then `vil.load` returns expected pixel information.